### PR TITLE
Several changes for Syncoid + general usage

### DIFF
--- a/restrict_zfs.py
+++ b/restrict_zfs.py
@@ -2,11 +2,15 @@ import os
 import re
 import syslog
 import sys
+import subprocess
 
 POOL = r"'[A-Za-z0-9_-]+'"
 DATASET = r"'[A-Za-z0-9_\/-]+'"
 DATASET_SNAPSHOT = r"'[A-Za-z0-9_\/-]+'@'[A-Za-z0-9:_-]+'"
 
+# Used when syncoid calls zfs destroy -- ONLY snapshots that match this regex will be allowed to be destroyed.
+# Note: Syncoid does NOT single quote the snapshot name as of version 2.1.0, but let's allow that.
+SYNCOID_SNAPSHOT = r"'[A-Za-z0-9_\/-]+'@('?)syncoid_[A-Za-z0-9:_-]+\1"
 
 # These commands were issued by Syncoid with standard options. If in your
 # usage you notice any commands that should be allowed but aren't allowed
@@ -20,11 +24,14 @@ ALLOWED_COMMANDS = [
     r'zfs get -H (name|receive_resume_token) ' + DATASET,
     r'zfs get -Hpd 1 -t snapshot guid,creation ' + DATASET,
     r'zfs get -H -p used ' + DATASET,
-    r' lzop -dfc \|  zfs receive  -s -F ' + DATASET,
-    r' lzop -dfc \|  zfs receive  -s -F ' + DATASET + r' 2>&1',
-    r' zfs rollback -R ' + DATASET_SNAPSHOT,
-    r' mbuffer (-r \d+[kM])? -q -s \d+[kM] -m \d+[kM] 2>\/dev\/null \| lzop -dfc \|  zfs receive  -s -F ' + DATASET,
-    r' mbuffer (-r \d+[kM])? -q -s \d+[kM] -m \d+[kM] 2>\/dev\/null \| lzop -dfc \|  zfs receive  -s -F ' + DATASET + ' 2>&1',
+    r'lzop -dfc \|  zfs receive  -s -F ' + DATASET,
+    r'lzop -dfc \|  zfs receive  -s -F ' + DATASET + r' 2>&1',
+    # If syncoid --no-sync-snap is *not* used, the following line may work with SYNCOID_SNAPSHOT
+    # instead of DATASET_SNAPSHOT to be more restrictive
+    r'zfs rollback -R ' + DATASET_SNAPSHOT,
+    r'mbuffer (-r \d+[kM])? -q -s \d+[kM] -m \d+[kM] 2>\/dev\/null \| lzop -dfc \|  zfs receive  -s (-F)? ' + DATASET,
+    r'mbuffer (-r \d+[kM])? -q -s \d+[kM] -m \d+[kM] 2>\/dev\/null \| lzop -dfc \|  zfs receive  -s (-F)? ' + DATASET + ' 2>&1',
+    r'zfs destroy ' + SYNCOID_SNAPSHOT,
 ]
 
 COMPILED = [re.compile(command) for command in ALLOWED_COMMANDS]
@@ -39,13 +46,19 @@ def check_allowed(command: str):
 
 
 if __name__ == '__main__':
-    command = os.environ['SSH_ORIGINAL_COMMAND']
+    original_command = os.environ['SSH_ORIGINAL_COMMAND']
 
-    is_allowed = check_allowed(command)
-    if not is_allowed:
-        syslog.syslog('blocked command: ' + command)
-        sys.exit(1)
+    # Syncoid can send multiple destroy commands separated by a semicolon when pruning.
+    # Split them so that we can validate each command on its own.
+    commands = original_command.split(';')
 
-    command2 = ['sh', '-c', command]
-    syslog.syslog('running command: ' + str(command2))
-    os.execlp(command2[0], *command2)
+    for command in commands:
+        command = command.strip()
+        is_allowed = check_allowed(command)
+        if not is_allowed:
+            syslog.syslog('blocked command: ' + command)
+            sys.exit(1)
+
+        command2 = ['sh', '-c', command]
+        syslog.syslog('running command: ' + str(command2))
+        subprocess.run(command2)

--- a/restrict_zfs.py
+++ b/restrict_zfs.py
@@ -3,10 +3,10 @@ import re
 import syslog
 import sys
 
+POOL = r"'[A-Za-z0-9_-]+'"
+DATASET = r"'[A-Za-z0-9_\/-]+'"
+DATASET_SNAPSHOT = r"'[A-Za-z0-9_\/-]+'@'[A-Za-z0-9:_-]+'"
 
-POOL = r"'[a-z0-9_-]+'"
-DATASET = r"'([a-z0-9_-]+\/?)+'"
-DATASET_SNAPSHOT = r"'([a-z0-9_-]+\/?)+'@'[a-z0-9:_-]+'"
 
 # These commands were issued by Syncoid with standard options. If in your
 # usage you notice any commands that should be allowed but aren't allowed


### PR DESCRIPTION
Hi!   
I had to change this script in quite a few ways to get it to work for me with Syncoid 2.1.0.

First, I sat scratching my head as to why almost NO command was accepted; turns out the regexes didn't accept uppercase letters in pool/dataset/snapshot names.  
After that, I still had to allow a few more command variations, and also allow it to destroy the snapshots it creates. To allow that in a safe manner, I wrote the regex such that it can only destroy its own snapshots (snapshots whose names begin with "syncoid_").

Syncoid also sends multiple destroy commands at once, separated by semicolons, so I also updated the script to split them on semicolons and verify the commands one at a time, to ensure you can't do something like "ps -Ao args=; rm -rf /*".

I also changed the regexes to not used nesting quantitative modifiers like +, to prevent a hang at 100% CPU while attempting to match. This does allow invalid dataset names (like only slashes), but I can't see a security risk in letting those through to the zfs command.

I haven't tested this thoroughly, but it does work for me with both initial and incremental sends.