### PR TITLE
Allow creating ZFS datasets

### DIFF
--- a/restrict_zfs.py
+++ b/restrict_zfs.py
@@ -54,6 +54,7 @@ ALLOWED_COMMANDS = [
     r'zfs destroy ' + DATASET_SNAPSHOT,
     r'zfs hold ' + SYNCOID_HOLD + r'\s+' + DATASET_SNAPSHOT,
     r'zfs release ' + SYNCOID_HOLD + r'\s+' + DATASET_SNAPSHOT,
+    r'zfs create (?:-p )?' + DATASET,
 ]
 
 COMPILED = [re.compile(command) for command in ALLOWED_COMMANDS]

--- a/restrict_zfs.py
+++ b/restrict_zfs.py
@@ -54,7 +54,7 @@ ALLOWED_COMMANDS = [
     r'zfs destroy ' + DATASET_SNAPSHOT,
     r'zfs hold ' + SYNCOID_HOLD + r'\s+' + DATASET_SNAPSHOT,
     r'zfs release ' + SYNCOID_HOLD + r'\s+' + DATASET_SNAPSHOT,
-    r'zfs create (?:-p )?' + DATASET,
+    r'zfs create (?:-p )? [\w\/-]+',
 ]
 
 COMPILED = [re.compile(command) for command in ALLOWED_COMMANDS]


### PR DESCRIPTION
Allow manual creation of ZFS datasets. Useful if you have custom logic that creates required datasets prior to running syncoid. Could not re-use `DATASET` regex since it includes single quotes, which leads to problems if you're sending variables via SSH command.