### PR TITLE
Allow dots in snapshot names

### DIFF
--- a/restrict_zfs.py
+++ b/restrict_zfs.py
@@ -9,10 +9,10 @@ from typing import cast
 
 POOL = r"'[\w-]+'"
 DATASET = r"'[\w\/-]+'"
-DATASET_SNAPSHOT = r"'[\w/-]+'@('?)[\w:-]+\1"
+DATASET_SNAPSHOT = r"'[\w/-]+'@('?)[\w.:-]+\1"
 
 # Note: Syncoid does NOT single quote the snapshot name as of version 2.1.0, but let's allow that.
-SYNCOID_SNAPSHOT = r"'[\w/-]+'@('?)syncoid_[\w:-]+\1"
+SYNCOID_SNAPSHOT = r"'[\w/-]+'@('?)syncoid_[\w.:-]+\1"
 
 SYNCOID_HOLD = r"[\w]+"
 


### PR DESCRIPTION
Syncoid adds the hostname into the snapshot name, which may contain dots if it's the FQDN.